### PR TITLE
Arreglado extract exploit en el login

### DIFF
--- a/scripts1/login.php
+++ b/scripts1/login.php
@@ -5,7 +5,11 @@ if (isset($_POST['username']) && isset($_POST['password'])) {
         $error = 'No se puede acceder a la base de datos';
     } else {
         // proceso de logueo
-        extract($_POST);
+        // extract($_POST);
+        // extraigo de a uno los parametros
+        $username = $_POST['username'];
+        $password = $_POST['password'];
+
         $consulta = "select * from usuarios where username = '$username' limit 1";
         $resultado = mysqli_query($conexion, $consulta);
         if ($resultado) {


### PR DESCRIPTION
Hola! Estaba buscando proyectos en github que usen la función de php "extract()" para poder ver si estos sitios son explotables o no. En este caso encontré un bug o inseguridad en el login que podría dejar acceder a cualquier persona solamente enviando un parámetro más en el POST request llamado '_SESSION[username]', sobreescribiendo esta variable que es la que controla si un usuario está logueado o no en el sistema.
El extract se puede usar para sobreescribir variables, incluso las de sesión ($_SESSION). Si esto es posible, por ejemplo uno podría sobreescribir la variable $_SESSION['username'] con cualquier valor y podría entrar al sistema sin saber la contraseña.
Para evitar esto es necesario asignar las variables que se pasan del formulario de a una al estilo:
`$username=$_POST['username'];
$password=$_POST['password'];`

O también usar algún flag como segundo parametro en el extract() para evitar sobreescribir variables de sesión, anque en la documentación hay ejemplos de esto, aclarando que no es una práctica recomendada. [PHP documentación](https://www.php.net/manual/es/function.extract.php)

Saludos!